### PR TITLE
fix(auth0-nuxt): explicitly define dependencies

### DIFF
--- a/packages/auth0-nuxt/package.json
+++ b/packages/auth0-nuxt/package.json
@@ -59,7 +59,8 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@auth0/auth0-server-js": "^1.0.3"
+    "@auth0/auth0-server-js": "^1.0.3",
+    "h3": "^1.15.4"
   },
   "files": [
     "dist",


### PR DESCRIPTION
We should ensure we define the dependency on h3 explicitly.