### PR TITLE
docs: Add Ask DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Auth0-Nuxt Mono Repo, containing SDK for implementing user authentication in Nux
 ![Release](https://img.shields.io/npm/v/@auth0/auth0-nuxt)
 ![Downloads](https://img.shields.io/npm/dw/@auth0/auth0-nuxt)
 [![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/auth0-nuxt)
 
 📚 [Packages](#packages) - 💬 [Feedback](#feedback)
 


### PR DESCRIPTION

This pull request adds the 'Ask DeepWiki' badge to the repository's README file.

### Purpose
The badge provides a direct and convenient link for users and contributors to ask questions and get information about this codebase via DeepWiki, improving the repository's overall supportability and accessibility.

### Automation Context
This change was applied via an automated script to ensure consistency across multiple repositories. No other files or functional code have been modified.
