### PR TITLE
feat(auth0-nuxt): forward query params as authorization params on login

### DIFF
--- a/packages/auth0-nuxt/src/runtime/server/api/auth/login.get.spec.ts
+++ b/packages/auth0-nuxt/src/runtime/server/api/auth/login.get.spec.ts
@@ -50,6 +50,7 @@ describe('login.get handler', () => {
 
     expect(mockAuth0Client.startInteractiveLogin).toHaveBeenCalledWith({
       appState: { returnTo: 'http://localhost:3000/foo' },
+      authorizationParams: undefined,
     });
   });
 
@@ -60,6 +61,66 @@ describe('login.get handler', () => {
 
     expect(mockAuth0Client.startInteractiveLogin).toHaveBeenCalledWith({
       appState: { returnTo: undefined },
+      authorizationParams: undefined,
+    });
+  });
+
+  it('should forward additional query params as authorizationParams', async () => {
+    getQueryMock.mockReturnValue({
+      returnTo: 'http://localhost:3000/foo',
+      organization: 'org_123',
+      login_hint: 'user@example.com',
+    });
+
+    await loginHandler(mockEvent);
+
+    expect(mockAuth0Client.startInteractiveLogin).toHaveBeenCalledWith({
+      appState: { returnTo: 'http://localhost:3000/foo' },
+      authorizationParams: {
+        organization: 'org_123',
+        login_hint: 'user@example.com',
+      },
+    });
+  });
+
+  it('should not forward returnTo or reserved OAuth params as authorizationParams', async () => {
+    getQueryMock.mockReturnValue({
+      returnTo: 'http://localhost:3000/foo',
+      scope: 'openid evil',
+      audience: 'https://evil',
+      redirect_uri: 'https://evil',
+      client_id: 'evil',
+      state: 'evil',
+      nonce: 'evil',
+      response_type: 'evil',
+      code_challenge: 'evil',
+      code_challenge_method: 'evil',
+      organization: 'org_123',
+    });
+
+    await loginHandler(mockEvent);
+
+    expect(mockAuth0Client.startInteractiveLogin).toHaveBeenCalledWith({
+      appState: { returnTo: 'http://localhost:3000/foo' },
+      authorizationParams: {
+        organization: 'org_123',
+      },
+    });
+  });
+
+  it('should not forward prototype-polluting keys as authorizationParams', async () => {
+    getQueryMock.mockReturnValue({
+      returnTo: 'http://localhost:3000/foo',
+      __proto__: 'evil',
+      constructor: 'evil',
+      prototype: 'evil',
+    });
+
+    await loginHandler(mockEvent);
+
+    expect(mockAuth0Client.startInteractiveLogin).toHaveBeenCalledWith({
+      appState: { returnTo: 'http://localhost:3000/foo' },
+      authorizationParams: undefined,
     });
   });
 

--- a/packages/auth0-nuxt/src/runtime/server/api/auth/login.get.ts
+++ b/packages/auth0-nuxt/src/runtime/server/api/auth/login.get.ts
@@ -6,6 +6,40 @@ interface LoginParams {
   returnTo?: string;
 }
 
+const DENIED_KEYS = new Set([
+  ...Object.getOwnPropertyNames(Object.prototype),
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
+const RESERVED_OAUTH_PARAMS = new Set([
+  'response_type',
+  'state',
+  'code_challenge',
+  'code_challenge_method',
+  'client_id',
+  'redirect_uri',
+  'nonce',
+  'scope',
+  'audience',
+]);
+
+function filterAuthorizationParams(
+  params: Record<string, unknown>,
+  disallowed: string[]
+): Record<string, unknown> | undefined {
+  const filtered: Record<string, unknown> = Object.create(null);
+
+  for (const [key, value] of Object.entries(params)) {
+    if (!DENIED_KEYS.has(key) && !disallowed.includes(key) && !RESERVED_OAUTH_PARAMS.has(key)) {
+      filtered[key] = value;
+    }
+  }
+
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
 export default defineEventHandler(async (event) => {
   const auth0Client = useAuth0(event);
   const auth0ClientOptions = event.context.auth0ClientOptions;
@@ -16,6 +50,7 @@ export default defineEventHandler(async (event) => {
 
   const authorizationUrl = await auth0Client.startInteractiveLogin({
     appState: { returnTo: sanitizedReturnTo },
+    authorizationParams: filterAuthorizationParams(query, ['returnTo']),
   });
 
   sendRedirect(event, authorizationUrl.href);


### PR DESCRIPTION
## Summary
- Forward additional query parameters from the login route to the authorization request via `authorizationParams`, mirroring the behavior in [`auth0-express`](https://github.com/auth0/auth0-express/blob/main/packages/auth0-express/src/handlers/login-handler.ts).
- Reserved OAuth parameters (`scope`, `audience`, `redirect_uri`, `client_id`, `state`, `nonce`, `response_type`, `code_challenge`, `code_challenge_method`), the `returnTo` param, and prototype-polluting keys are filtered out before being passed through.

This lets consumers initiate login with params like `organization`, `login_hint`, or `prompt` by appending them to the login URL, e.g. `/auth/login?organization=org_123`.

## Test plan
- [x] `npm run test:unit` — 47 tests pass, including 4 new cases:
  - forwards extra query params as `authorizationParams`
  - filters reserved OAuth params
  - filters `returnTo`
  - filters prototype-polluting keys (`__proto__`, `constructor`, `prototype`)
- [x] `npm run lint` passes