### PR TITLE
ci: drop Node 20 from test matrices

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [ 20, 22, 24 ]
+        node: [ 22, 24 ]
     name: Build Package
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [ 20, 22, 24 ]
+        node: [ 22, 24 ]
     name: Build Package
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- Nuxt 4.4.8 (bumped in #43) requires Node `^22.12.0 || ^24.11.0 || >=26.0.0`, dropping Node 20 support.
- The CI matrices in `test.yml` and `build-examples.yml` still tested Node 20, causing the Nuxt SSR build to fail there (surfaced as an esbuild `(define name): Expected identifier but found "false"/"true"` error on `nuxt/dist/app/entry.js`).
- This made `main` red since #43 landed; unrelated PRs inherited the failure.

## Fix
- Drop Node 20 from both CI matrices, leaving 22 and 24 — matching Nuxt's supported runtimes.

## Test plan
- [x] CI passes on Node 22 and 24 across `test.yml` and `build-examples.yml`.