### PR TITLE
test: use a syntactically valid domain in middleware test

### DIFF
--- a/packages/auth0-nuxt/test/middleware.test.ts
+++ b/packages/auth0-nuxt/test/middleware.test.ts
@@ -11,7 +11,7 @@ describe('auth.server middleware', async () => {
       ssr: true,
       runtimeConfig: {
         auth0: {
-          domain: '<domain>',
+          domain: 'example.auth0.local',
           clientId: '<client_id>',
           clientSecret: '<client_secret>',
           sessionSecret: '<secret>',


### PR DESCRIPTION
## Summary

The `auth.server` middleware test passed the literal placeholder `'<domain>'` as the Auth0 domain. Since **@auth0/auth0-server-js 1.6.0**, the `ServerClient` constructor validates the domain by running it through `new URL()` (added with the resolver/multi-domain support). `new URL('https://<domain>')` throws `Invalid URL` because `<` and `>` are illegal in a hostname, so `getUser()` throws and the test fails.

## Change

`domain: '<domain>'` → `domain: 'example.auth0.local'` in `middleware.test.ts` — a syntactically valid host that never resolves (no network calls), so the test is robust across SDK versions.

## Verification

- `middleware.test.ts` passes against server-js 1.6.1 (the version a fresh install resolves)
- Full unit suite (44 tests) + lint green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to use a concrete local domain value instead of a placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->