### PR TITLE
fix: harden SSR cache guard against case-sensitivity bypass (CVE-2026-53721)

### DIFF
--- a/packages/auth0-nuxt/src/runtime/middleware/auth.server.spec.ts
+++ b/packages/auth0-nuxt/src/runtime/middleware/auth.server.spec.ts
@@ -1,21 +1,25 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { getUserMock, getRouteRulesMock } = vi.hoisted(() => ({
+const { getUserMock, getRouteRulesMock, eventRef } = vi.hoisted(() => ({
   getUserMock: vi.fn(),
   getRouteRulesMock: vi.fn(),
+  eventRef: { path: '/some-path' },
 }));
 
 vi.mock('#app/nuxt', async (importOriginal) => {
   const actual = await importOriginal<typeof import('#app/nuxt')>();
   return {
     ...actual,
-    useNuxtApp: vi.fn(() => ({ ssrContext: { event: { path: '/some-path' } } })),
+    useNuxtApp: vi.fn(() => ({ ssrContext: { event: eventRef } })),
   };
 });
 
 // The middleware reads the route rules Nitro resolved for the request through Nitro's
 // supported `getRouteRules` server util, imported dynamically from `nitropack/runtime`.
+// It is called once for the request path and once for a lowercased synthetic event, to
+// harden against the case-sensitivity matcher bypass (CVE-2026-53721); the mock dispatches
+// on the event's `path` so tests can return different rules per casing.
 vi.mock('nitropack/runtime', () => ({
   getRouteRules: getRouteRulesMock,
 }));
@@ -39,6 +43,7 @@ import middleware from './auth.server';
 beforeEach(() => {
   vi.clearAllMocks();
   userState.value = undefined;
+  eventRef.path = '/some-path';
   getUserMock.mockResolvedValue({ sub: 'user-1' });
 });
 
@@ -67,6 +72,22 @@ describe('auth.server middleware', () => {
   it('skips the user write (fails closed) when route rules are unavailable', async () => {
     getRouteRulesMock.mockReturnValue(undefined);
     await (middleware as unknown as () => Promise<void>)();
+    expect(getUserMock).not.toHaveBeenCalled();
+    expect(userState.value).toBeUndefined();
+  });
+
+  it('skips the user write when only the lowercased path is shared-cacheable (CVE-2026-53721)', async () => {
+    // Simulate the case-sensitivity bypass: the route is requested with mixed casing.
+    // Nitro's matcher is case-sensitive, so the exact-path lookup finds no rule, but the
+    // page still renders (vue-router is case-insensitive). The guard must also consult the
+    // lowercased path so the shared-cacheable rule is not bypassed.
+    eventRef.path = '/Cacheable';
+    getRouteRulesMock.mockImplementation((event: { path: string }) =>
+      event.path === '/cacheable' ? { headers: { 'Cache-Control': 'public, s-maxage=900' } } : {}
+    );
+
+    await (middleware as unknown as () => Promise<void>)();
+
     expect(getUserMock).not.toHaveBeenCalled();
     expect(userState.value).toBeUndefined();
   });

--- a/packages/auth0-nuxt/src/runtime/middleware/auth.server.ts
+++ b/packages/auth0-nuxt/src/runtime/middleware/auth.server.ts
@@ -25,17 +25,27 @@ export default defineNuxtRouteMiddleware(async () => {
     // `Cache-Control` *header* route rules, so it would not detect the shared-cacheable
     // case this guard exists for. Imported dynamically (server-only) to keep it out of
     // the client bundle; `isSharedCacheable` fails closed if it is unavailable.
-    const { getRouteRules } = await import("nitropack/runtime");
-    const routeRules = getRouteRules(h3Event);
-    if (isSharedCacheable(routeRules)) {
-      if (importMetaDev && !warnedPaths.has(h3Event.path)) {
-        warnedPaths.add(h3Event.path);
-        console.warn(
-          `[auth0-nuxt] Route "${h3Event.path}" is shared-cacheable; skipping the SSR user write to keep cached HTML anonymous. ` +
-            `The user will be hydrated client-side from the profile endpoint.`
-        );
-      }
+    const { getRouteRules } = await import('nitropack/runtime');
+
+    // First check the rules for the request path as-is.
+    if (isSharedCacheable(getRouteRules(h3Event))) {
+      maybeWarn(h3Event.path);
       return;
+    }
+
+    // Then re-check against the lowercased path. Nitro's route-rule matcher is
+    // case-sensitive, but vue-router matches routes case-insensitively, so a request like
+    // `/Cacheable` renders the `/cacheable` page while dodging its route rule
+    // (CVE-2026-53721). We resolve the rules for the lowercased path too — via a synthetic
+    // event with a fresh context so `getRouteRules` recomputes rather than returning the
+    // cached result — so the cache guard cannot be bypassed by casing.
+    const lowerPath = h3Event.path.toLowerCase();
+    if (lowerPath !== h3Event.path) {
+      const lowerEvent = { ...h3Event, path: lowerPath, context: {} } as typeof h3Event;
+      if (isSharedCacheable(getRouteRules(lowerEvent))) {
+        maybeWarn(h3Event.path);
+        return;
+      }
     }
 
     // As we can only import this composable on the server, we need to dynamically import it.
@@ -47,3 +57,13 @@ export default defineNuxtRouteMiddleware(async () => {
     useUser().value = user;
   }
 });
+
+function maybeWarn(path: string): void {
+  if (importMetaDev && !warnedPaths.has(path)) {
+    warnedPaths.add(path);
+    console.warn(
+      `[auth0-nuxt] Route "${path}" is shared-cacheable; skipping the SSR user write to keep cached HTML anonymous. ` +
+        `The user will be hydrated client-side from the profile endpoint.`
+    );
+  }
+}

--- a/packages/auth0-nuxt/test/caching.test.ts
+++ b/packages/auth0-nuxt/test/caching.test.ts
@@ -85,4 +85,17 @@ describe('SSR caching and PII in the payload (#52)', async () => {
     expect(html).not.toContain(SUB);
     expect(html).toContain('anonymous');
   });
+
+  it('does NOT server-render the user on a case-variant of a shared-cacheable route (CVE-2026-53721)', async () => {
+    // vue-router renders `/cacheable` for a mixed-case request, but Nitro's route-rule
+    // matcher is case-sensitive, so `/Cacheable` would dodge the shared-cacheable rule.
+    // The guard re-checks the lowercased path, so the user must still be absent.
+    const html: string = await $fetch('/Cacheable', {
+      headers: { cookie: await sessionCookie() },
+    });
+
+    expect(html).not.toContain(SUB);
+    expect(html).not.toContain(EMAIL);
+    expect(html).toContain('anonymous');
+  });
 });


### PR DESCRIPTION
## Summary

The #52 cache guard reads route rules via `getRouteRules` to decide whether to write the authenticated user into the SSR payload. **Nitro's route-rule matcher is case-sensitive, but vue-router matches routes case-insensitively** — so a mixed-case request (e.g. `/Cacheable`) renders the `/cacheable` page while resolving **no** route rule. The guard therefore doesn't fire, and the user is written into SSR HTML the consumer marked `Cache-Control: public, s-maxage`. This is CVE-2026-53721.

**Confirmed live in this repo** (reproduced before the fix): `/Cacheable` returns the user's `sub`/`email` in the raw SSR HTML; `/cacheable` does not.

### Why patched Nuxt doesn't cover us

Nuxt's fix (4.4.7 / 3.21.7) lowercases the path only in its **app-level** matcher and a `nitro-server` integration. The `nitropack/runtime` `getRouteRules` that this middleware uses is a different code path the patch does not touch, so the bypass still reproduces on patched Nuxt (verified on 4.4.8).

## Fix

After checking the request path as-is, re-resolve route rules for the **lowercased** path (via a synthetic event with a fresh context so `getRouteRules` recomputes rather than returning the cached result) and skip the write if **either** is shared-cacheable. Skipping is always fail-safe — the client hydrates the user.

## Tests

- Unit: a shared-cacheable rule reachable only via the lowercased path still skips the write.
- e2e (`caching.test.ts`): `/Cacheable` renders **anonymous** SSR HTML (it leaked before the fix).
- Full unit suite (65) + lint + build green.

## Scope / base

Based on `issue-52` because it hardens that branch's cache guard directly. The same fix (extended to cover the `auth0.ssrUser` opt-out) is also part of #55; this PR ensures the core #52 guard is protected independently of #55's merge timing.

> Note: this guard is best-effort by design — it cannot detect caching set imperatively (`setHeader`) or by an external CDN. That limitation is documented separately; the robust posture for shared-cache apps is the global opt-out + per-route opt-in (#55).